### PR TITLE
fix Ambiguous class resolution for symfony contracts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "fzaninotto/faker": "^1.6",
         "sylius/sylius": "^1.6",
         "symfony/framework-bundle": "^4.4",
-        "symfony/contracts": "^1.1|^2.0"
+        "symfony/service-contracts": "^1.1|^2.0"
     },
     "require-dev": {
         "behat/behat": "^3.4",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?   | yes
| Fixed issue | 

Updated requirement symfony/contracts to symfony/service-contracts installation does not generate ambiguous classes with an optimized composer autoloader.
