### PR TITLE
Faker php is locked at ^1.9 for Sylius 1.9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "license": "MIT",
     "require": {
         "php": "^7.2",
-        "fakerphp/faker": "^1.9|^1.13",
+        "fakerphp/faker": "^1.9",
         "sylius/sylius": "^1.6",
         "symfony/framework-bundle": "^4.4|^5.2",
         "symfony/service-contracts": "^1.1|^2.0"

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "license": "MIT",
     "require": {
         "php": "^7.2",
-        "fakerphp/faker": "^1.9 || ^1.13",
+        "fakerphp/faker": "^1.9|^1.13",
         "sylius/sylius": "^1.6",
         "symfony/framework-bundle": "^4.4|^5.2",
         "symfony/service-contracts": "^1.1|^2.0"

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "license": "MIT",
     "require": {
         "php": "^7.2",
-        "fakerphp/faker": "^1.13",
+        "fakerphp/faker": "^1.9 || ^1.13",
         "sylius/sylius": "^1.6",
         "symfony/framework-bundle": "^4.4|^5.2",
         "symfony/service-contracts": "^1.1|^2.0"


### PR DESCRIPTION
Add compatibility for sylius 1.9

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| License       | MIT

Faker php is locked at ^1.9 for Sylius 1.9:

https://github.com/Sylius/Sylius/blob/1.9/composer.json#L37
