### PR TITLE
Better handling of Sylius Plus

### DIFF
--- a/src/Controller/MailTesterController.php
+++ b/src/Controller/MailTesterController.php
@@ -116,10 +116,18 @@ final class MailTesterController extends AbstractController
             $emailData = $form->getData()[$type];
         }
 
-        if ($form->has('form_subject_chosen') && $form->get('form_subject_chosen')->has('promotionCoupon')) {
-            /** @var PromotionCoupon $promotionCoupon */
-            $promotionCoupon = $form->get('form_subject_chosen')->get('promotionCoupon')->getData();
-            $emailData['couponCode'] = $promotionCoupon->getCode();
+        if (class_exists('Sylius\Plus\SyliusPlusPlugin')) {
+            if ($form->has('form_subject_chosen') && $form->get('form_subject_chosen')->has('promotionCoupon')) {
+                /** @var PromotionCoupon $promotionCoupon */
+                $promotionCoupon = $form->get('form_subject_chosen')->get('promotionCoupon')->getData();
+                $emailData['couponCode'] = $promotionCoupon->getCode();
+            }
+
+            if ($form->has('subjects') && $form->get('subjects')->getData() === ChoiceSubjectsType::EVERY_SUBJECTS) {
+                /** @var PromotionCoupon $promotionCoupon */
+                $promotionCoupon = $form->get('sylius_plus_loyalty_purchase_coupon')->getData()['promotionCoupon'];
+                $emailData['couponCode'] = $promotionCoupon->getCode();
+            }
         }
 
         $emailData['localeCode'] = $form->get('localeCode')->getData()->getCode();

--- a/src/Form/Type/MailTesterType.php
+++ b/src/Form/Type/MailTesterType.php
@@ -43,6 +43,11 @@ final class MailTesterType extends AbstractType
         if (isset($options['data']['form_every_subjects'])) {
             /** @var ResolvableFormTypeInterface $subject */
             foreach ($options['data']['form_every_subjects'] as $subject) {
+                if (!class_exists('Sylius\Plus\SyliusPlusPlugin')) {
+                    if (\substr($subject->getCode(), 0, 11) === 'sylius_plus') {
+                        continue;
+                    }
+                }
                 $builder->add(
                     $subject->getCode(),
                     get_class($subject),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Fixed issue   | 
| License       | MIT


If you have Sylius Plus you got error ;
```
Error
Variable "couponCode" does not exist.
```

In this PR, I fix it and hide the forms for Sylius Plus if you don't have it installed.