### PR TITLE
Send all mails, remove Sylius 1.9 compatibility and use constants

### DIFF
--- a/.github/workflows/sylius.yaml
+++ b/.github/workflows/sylius.yaml
@@ -20,7 +20,6 @@ jobs:
                     - 8.0
                     - 8.1
                 sylius:
-                    - 1.9.0
                     - 1.10.0
                     - 1.11.0
                     - 1.12.0
@@ -31,17 +30,8 @@ jobs:
                     - 14.x
                 exclude:
                     -
-                        sylius: 1.9.0
-                        php: 8.0
-                    -
-                        sylius: 1.9.0
-                        php: 8.1
-                    -
                         sylius: 1.11.0
                         php: 7.4
-                    -
-                        sylius: 1.9.0
-                        symfony: 6.1
                     -
                         sylius: 1.10.0
                         symfony: 6.1

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 |        | Version    |
 |:-------|:-----------|
 | PHP    | ^7.4, ^8.0 |
-| Sylius | ^1.9       |
+| Sylius | ^1.10      |
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "fakerphp/faker": "^1.9",
-        "sylius/sylius": "^1.9",
+        "sylius/sylius": "^1.10",
         "symfony/framework-bundle": "^5.4|^6.0",
         "symfony/service-contracts": "^1.1|^2.0|^3.0",
         "webmozart/assert": "^1.8"

--- a/src/Controller/MailTesterController.php
+++ b/src/Controller/MailTesterController.php
@@ -15,6 +15,7 @@ use Synolia\SyliusMailTesterPlugin\Form\Type\AbstractType;
 use Synolia\SyliusMailTesterPlugin\Form\Type\ChoiceSubjectsType;
 use Synolia\SyliusMailTesterPlugin\Form\Type\MailTesterType;
 use Synolia\SyliusMailTesterPlugin\Resolver\FormTypeResolver;
+use Synolia\SyliusMailTesterPlugin\Resolver\ResolvableMultipleFormTypeInterface;
 
 final class MailTesterController extends AbstractController
 {
@@ -82,6 +83,16 @@ final class MailTesterController extends AbstractController
             if ($mailTester['subjects'] === ChoiceSubjectsType::EVERY_SUBJECTS) {
                 /** @var AbstractType $formSubject */
                 foreach ($this->formTypeResolver->getAllFormTypes() as $formSubject) {
+                    if ($formSubject instanceof ResolvableMultipleFormTypeInterface) {
+                        foreach ($formSubject->getCodes() as $code) {
+                            if (array_key_exists($code, $this->emails)) {
+                                $sender->send($code, [$formData['recipient']], $this->getMailData($form, $code));
+                            }
+                        }
+
+                        continue;
+                    }
+
                     if (array_key_exists($formSubject->getCode(), $this->emails)) {
                         $sender->send($formSubject->getCode(), [$formData['recipient']], $this->getMailData($form, $formSubject->getCode()));
                     }

--- a/src/Form/Type/AbstractMultipleKeysType.php
+++ b/src/Form/Type/AbstractMultipleKeysType.php
@@ -21,6 +21,14 @@ abstract class AbstractMultipleKeysType extends \Symfony\Component\Form\Abstract
         return static::$syliusEmailKeys[0];
     }
 
+    /**
+     * @return string[]
+     */
+    public function getCodes(): array
+    {
+        return static::$syliusEmailKeys;
+    }
+
     public function getFormType(string $emailKey): ResolvableFormTypeInterface
     {
         return $this;

--- a/src/Form/Type/ContactRequestType.php
+++ b/src/Form/Type/ContactRequestType.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Synolia\SyliusMailTesterPlugin\Form\Type;
 
+use Sylius\Bundle\CoreBundle\Mailer\Emails;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -12,7 +13,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 final class ContactRequestType extends AbstractType
 {
     /** @var string */
-    protected static $syliusEmailKey = 'contact_request';
+    protected static $syliusEmailKey = Emails::CONTACT_REQUEST;
 
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/src/Form/Type/MailTesterType.php
+++ b/src/Form/Type/MailTesterType.php
@@ -11,6 +11,7 @@ use Symfony\Component\Form\Extension\Core\Type\EmailType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Synolia\SyliusMailTesterPlugin\Resolver\ResolvableFormTypeInterface;
+use Synolia\SyliusMailTesterPlugin\Resolver\ResolvableMultipleFormTypeInterface;
 
 final class MailTesterType extends AbstractType
 {
@@ -48,11 +49,22 @@ final class MailTesterType extends AbstractType
                         continue;
                     }
                 }
-                $builder->add(
-                    $subject->getCode(),
-                    get_class($subject),
-                    ['label_attr' => ['class' => 'ui massive label']]
-                );
+
+                if ($subject instanceof ResolvableMultipleFormTypeInterface) {
+                    foreach ($subject->getCodes() as $code) {
+                        $builder->add(
+                            $code,
+                            get_class($subject),
+                            ['label_attr' => ['class' => 'ui massive label']]
+                        );
+                    }
+                } else {
+                    $builder->add(
+                        $subject->getCode(),
+                        get_class($subject),
+                        ['label_attr' => ['class' => 'ui massive label']]
+                    );
+                }
             }
             $builder->add(
                 'submit',

--- a/src/Form/Type/OrderConfirmationType.php
+++ b/src/Form/Type/OrderConfirmationType.php
@@ -4,14 +4,15 @@ declare(strict_types=1);
 
 namespace Synolia\SyliusMailTesterPlugin\Form\Type;
 
+use Sylius\Bundle\CoreBundle\Mailer\Emails;
 use Symfony\Component\Form\FormBuilderInterface;
 
 final class OrderConfirmationType extends AbstractMultipleKeysType
 {
     /** @var array<string> */
     protected static $syliusEmailKeys = [
-        'order_confirmation',
-        'order_confirmation_resent',
+        Emails::ORDER_CONFIRMATION,
+        Emails::ORDER_CONFIRMATION_RESENT,
     ];
 
     /** @var string */

--- a/src/Form/Type/PasswordTokenResetType.php
+++ b/src/Form/Type/PasswordTokenResetType.php
@@ -6,6 +6,8 @@ namespace Synolia\SyliusMailTesterPlugin\Form\Type;
 
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\QueryBuilder;
+use Sylius\Bundle\CoreBundle\Mailer\Emails;
+use Sylius\Bundle\UserBundle\Mailer\Emails as UserBundleEmails;
 use Sylius\Component\User\Model\UserInterface;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -15,9 +17,9 @@ use Symfony\Component\Form\FormEvents;
 final class PasswordTokenResetType extends AbstractMultipleKeysType
 {
     protected static $syliusEmailKeys = [
-        'password_reset',
-        'reset_password_token',
-        'reset_password_pin',
+        Emails::PASSWORD_RESET,
+        UserBundleEmails::RESET_PASSWORD_TOKEN,
+        UserBundleEmails::RESET_PASSWORD_PIN,
     ];
 
     /** @var string */

--- a/src/Form/Type/ShipmentConfirmation.php
+++ b/src/Form/Type/ShipmentConfirmation.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Synolia\SyliusMailTesterPlugin\Form\Type;
 
+use Sylius\Bundle\CoreBundle\Mailer\Emails;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\ShipmentInterface;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -11,7 +12,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 final class ShipmentConfirmation extends AbstractType
 {
     /** @var string */
-    protected static $syliusEmailKey = 'shipment_confirmation';
+    protected static $syliusEmailKey = Emails::SHIPMENT_CONFIRMATION;
 
     /** @var string */
     private $syliusOrderClass;

--- a/src/Form/Type/VerificationTokenType.php
+++ b/src/Form/Type/VerificationTokenType.php
@@ -6,6 +6,7 @@ namespace Synolia\SyliusMailTesterPlugin\Form\Type;
 
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\QueryBuilder;
+use Sylius\Bundle\UserBundle\Mailer\Emails;
 use Sylius\Component\User\Model\UserInterface;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -15,7 +16,7 @@ use Symfony\Component\Form\FormEvents;
 final class VerificationTokenType extends AbstractType
 {
     /** @var string */
-    protected static $syliusEmailKey = 'verification_token';
+    protected static $syliusEmailKey = Emails::EMAIL_VERIFICATION_TOKEN;
 
     /** @var string */
     private $syliusShopUserClass;

--- a/src/Resolver/ResolvableMultipleFormTypeInterface.php
+++ b/src/Resolver/ResolvableMultipleFormTypeInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Synolia\SyliusMailTesterPlugin\Resolver;
+
+interface ResolvableMultipleFormTypeInterface extends ResolvableFormTypeInterface
+{
+    public function getCodes(): array;
+}

--- a/tests/PHPUnit/Resolver/FormTypeResolverTest.php
+++ b/tests/PHPUnit/Resolver/FormTypeResolverTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Tests\Synolia\SyliusMailTesterPlugin\PHPUnit\Resolver;
 
+use Sylius\Bundle\CoreBundle\Mailer\Emails;
+use Sylius\Bundle\UserBundle\Mailer\Emails as UserBundleEmails;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Form\FormTypeInterface;
 use Synolia\SyliusMailTesterPlugin\Resolver\FormTypeResolver;
@@ -53,15 +55,15 @@ final class FormTypeResolverTest extends KernelTestCase
     public function provideEmailKeyAndExpectedForm(): \Generator
     {
         yield 'Refund plugin' => ['units_refunded', \Synolia\SyliusMailTesterPlugin\Form\Type\Plugin\RefundPlugin\UnitsRefundedType::class];
-        yield 'Contact request' => ['contact_request', \Synolia\SyliusMailTesterPlugin\Form\Type\ContactRequestType::class];
-        yield 'Order confirmation' => ['order_confirmation', \Synolia\SyliusMailTesterPlugin\Form\Type\OrderConfirmationType::class];
-        yield 'Order confirmation resend' => ['order_confirmation_resent', \Synolia\SyliusMailTesterPlugin\Form\Type\OrderConfirmationType::class];
-        yield 'Password reset' => ['password_reset', \Synolia\SyliusMailTesterPlugin\Form\Type\PasswordTokenResetType::class];
-        yield 'Password reset token' => ['reset_password_token', \Synolia\SyliusMailTesterPlugin\Form\Type\PasswordTokenResetType::class];
-        yield 'Password reset pin' => ['reset_password_pin', \Synolia\SyliusMailTesterPlugin\Form\Type\PasswordTokenResetType::class];
-        yield 'Shipment confirmation' => ['shipment_confirmation', \Synolia\SyliusMailTesterPlugin\Form\Type\ShipmentConfirmation::class];
-        yield 'User Registration' => ['user_registration', \Synolia\SyliusMailTesterPlugin\Form\Type\UserRegistrationType::class];
-        yield 'Token verification' => ['verification_token', \Synolia\SyliusMailTesterPlugin\Form\Type\VerificationTokenType::class];
+        yield 'Contact request' => [Emails::CONTACT_REQUEST, \Synolia\SyliusMailTesterPlugin\Form\Type\ContactRequestType::class];
+        yield 'Order confirmation' => [Emails::ORDER_CONFIRMATION, \Synolia\SyliusMailTesterPlugin\Form\Type\OrderConfirmationType::class];
+        yield 'Order confirmation resend' => [Emails::ORDER_CONFIRMATION_RESENT, \Synolia\SyliusMailTesterPlugin\Form\Type\OrderConfirmationType::class];
+        yield 'Password reset' => [Emails::PASSWORD_RESET, \Synolia\SyliusMailTesterPlugin\Form\Type\PasswordTokenResetType::class];
+        yield 'Password reset token' => [UserBundleEmails::RESET_PASSWORD_TOKEN, \Synolia\SyliusMailTesterPlugin\Form\Type\PasswordTokenResetType::class];
+        yield 'Password reset pin' => [UserBundleEmails::RESET_PASSWORD_PIN, \Synolia\SyliusMailTesterPlugin\Form\Type\PasswordTokenResetType::class];
+        yield 'Shipment confirmation' => [Emails::SHIPMENT_CONFIRMATION, \Synolia\SyliusMailTesterPlugin\Form\Type\ShipmentConfirmation::class];
+        yield 'User Registration' => [Emails::USER_REGISTRATION, \Synolia\SyliusMailTesterPlugin\Form\Type\UserRegistrationType::class];
+        yield 'Token verification' => [UserBundleEmails::EMAIL_VERIFICATION_TOKEN, \Synolia\SyliusMailTesterPlugin\Form\Type\VerificationTokenType::class];
         yield '[Plus] Return request confirmation' => ['sylius_plus_return_request_confirmation', \Synolia\SyliusMailTesterPlugin\Form\Type\SyliusPlusReturnRequestType::class];
         yield '[Plus] Return request accepted' => ['sylius_plus_return_request_accepted', \Synolia\SyliusMailTesterPlugin\Form\Type\SyliusPlusReturnRequestType::class];
         yield '[Plus] Return request rejected' => ['sylius_plus_return_request_rejected', \Synolia\SyliusMailTesterPlugin\Form\Type\SyliusPlusReturnRequestType::class];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Fixed issue   | 
| License       | MIT

The plugin doesn't send all emails if there are several for a Form.

For exemple in SyliusPlusReturnRequestType, mails are :

- 'sylius_plus_return_request_confirmation',
- 'sylius_plus_return_request_accepted',
- 'sylius_plus_return_request_rejected',
- 'sylius_plus_return_request_resolution_changed',
- 'sylius_plus_return_request_repaired_items_sent',

but just the first was send, it's now fixed.
I also use Constants from Sylius when they exists ;) 

